### PR TITLE
Fixes related to ijon-max and pin afl-clang-fast to the llvm version used to compile it 

### DIFF
--- a/llvm_mode/Makefile
+++ b/llvm_mode/Makefile
@@ -23,18 +23,20 @@ BIN_PATH     = $(PREFIX)/bin
 VERSION     = $(shell grep '^\#define VERSION ' ../config.h | cut -d '"' -f2)
 
 LLVM_CONFIG ?= llvm-config
+LLVM_BINDIR = $(shell $(LLVM_CONFIG) --bindir 2>/dev/null)
 
 CFLAGS      ?= -O3 -funroll-loops
 CFLAGS      += -Wall -D_FORTIFY_SOURCE=2 -g -Wno-pointer-sign \
                -DAFL_PATH=\"$(HELPER_PATH)\" -DBIN_PATH=\"$(BIN_PATH)\" \
-               -DVERSION=\"$(VERSION)\" 
+               -DLLVM_BINDIR=\"$(LLVM_BINDIR)\" -DVERSION=\"$(VERSION)\" 
 ifdef AFL_TRACE_PC
   CFLAGS    += -DUSE_TRACE_PC=1
 endif
 
 CXXFLAGS    ?= -O3 -funroll-loops
 CXXFLAGS    += -Wall -D_FORTIFY_SOURCE=2 -g -Wno-pointer-sign \
-               -DVERSION=\"$(VERSION)\" -Wno-variadic-macros
+               -DLLVM_BINDIR=\"$(LLVM_BINDIR)\" -DVERSION=\"$(VERSION)\" \
+               -Wno-variadic-macros
 
 CLANG_CFL    = `$(LLVM_CONFIG) --cxxflags` -fno-rtti -fpic $(CXXFLAGS)
 CLANG_LFL    = `$(LLVM_CONFIG) --ldflags` $(LDFLAGS)

--- a/llvm_mode/afl-llvm-pass.so.cc
+++ b/llvm_mode/afl-llvm-pass.so.cc
@@ -49,6 +49,28 @@ namespace {
       static char ID;
       AFLCoverage() : ModulePass(ID) { }
 
+      // ripped from aflgo
+      static bool isBlacklisted(const Function *F) {
+
+        static const char *Blacklist[] = {
+
+            "asan.",
+            "llvm.",
+            "sancov.",
+            "__ubsan_handle_",
+
+        };
+
+        for (auto const &BlacklistFunc : Blacklist) {
+
+          if (F->getName().startswith(BlacklistFunc)) { return true; }
+
+        }
+
+        return false;
+
+      }
+
       bool runOnModule(Module &M) override;
 
       // StringRef getPassName() const override {
@@ -118,7 +140,10 @@ bool AFLCoverage::runOnModule(Module &M) {
 
   int inst_blocks = 0;
 
-  for (auto &F : M)
+  for (auto &F : M) {
+  
+    if (isBlacklisted(&F)) continue;
+  
     for (auto &BB : F) {
 
       BasicBlock::iterator IP = BB.getFirstInsertionPt();
@@ -174,6 +199,8 @@ bool AFLCoverage::runOnModule(Module &M) {
       inst_blocks++;
 
     }
+    
+  }
 
   /* Say something nice. */
 

--- a/readme.md
+++ b/readme.md
@@ -14,9 +14,11 @@ IJON is an annotation mechanism that analysts can use to guide fuzzers such as A
 
 
 
-More data and the results of the experiments can be found here:
+More data and the results of the experiments can be found 
+<a href="https://github.com/RUB-SysSec/ijon-data/blob/master/readme.md">here:<br>
 
-<a href="https://github.com/RUB-SysSec/ijon-data/README.md"><img title="" src="/img/demo.gif" alt="" width="550" align="center"></a>
+<img title="" src="/img/demo.gif" alt="" width="550" align="center">
+</a>
 
 ## Compile AFL+IJON
 


### PR DESCRIPTION
Added stuffs:

+ LLVM blacklist from aflgo, you don't want to instrument for instance UBSan handles
+ afl-clang-fast now, if AFL_CC is not set, uses the compiler used to compile llvm_mode

Solved bugs:

+ at the end of fuzz_one, munmap was using the wrong len when is_doing_ijon = 1. This causes a SEGV cause the shared memory is unmapped after a while.
+ Skip the not favored testcases in fuzz_one after that we choose if use ijon-max or not. The old code polluted the favored selection algorithm.
+ (Dirty) fix a SIGBUS generated in locate_diffs disabling splicing when doing ijon-max.